### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot-label-standardisation.yaml
+++ b/.github/workflows/dependabot-label-standardisation.yaml
@@ -1,4 +1,7 @@
 name: Standardise Dependabot labels
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
     pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/placer-toolkit/placer-toolkit/security/code-scanning/1](https://github.com/placer-toolkit/placer-toolkit/security/code-scanning/1)

To fix this issue, add a `permissions` block to the workflow at either the root level (making the permissions apply globally) or within the specific job (to apply only to that job). The steps in this workflow manipulate pull request labels, which requires read access to repository contents and write access to pull requests (`contents: read`, `pull-requests: write`). To minimally comply with best practices, add this at the workflow root, just after the `name:` and before `on:`, or inside the job definition before `runs-on:`. Since there is only a single job and the recommended fix was cited at the workflow root, we will add:  
```yaml
permissions:
  contents: read
  pull-requests: write
```  
after `name: Standardise Dependabot labels`.

No additional methods or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
