### PR TITLE
docs(get-started/localisation): Fix indentation of `de` locale item

### DIFF
--- a/docs/src/content/get-started/localisation.mdx
+++ b/docs/src/content/get-started/localisation.mdx
@@ -31,7 +31,7 @@ We will list the available translations categorised by language family.
 #### Germanic
 
 - Dansk (da)
-    - Deutsch (de)
+- Deutsch (de)
     - Deutsch (Österreich) (de-at)
     - Deutsch (Schweiz) (de-ch)
 - English (en)


### PR DESCRIPTION
### ✨ Type of change

- [X] Bug fix (non‐breaking change which fixes an issue)
- [ ] New feature (non‐breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code restructuring, no new features or bug fixes)
- [X] Documentation update
- [ ] Chore (dependency updates, build process changes, etc.)

### 📝 Description of changes

This PR fixes the indentation of the “Deutsch (de)” locale item.

### ✅ Checklist

- [X] My code follows the [Placer Style Guide](https://github.com/placer-toolkit/placer-style-guide). I also understand and agree to the mandatory, absolute nature of the style guide; in which I accept the [defined consequences](https://github.com/placer-toolkit/placer-toolkit/blob/main/PLACER_STYLE_GUIDE_VIOLATION.md) if I fail.
- [X] I have performed a self‐review of my own code.
- [X] I have commented my code, particularly in hard‐to‐understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.
